### PR TITLE
Add strip-comments

### DIFF
--- a/lib/paru/pandoc_options_version_2.yaml
+++ b/lib/paru/pandoc_options_version_2.yaml
@@ -43,6 +43,7 @@ dpi:                        96
 eol:                        "native"
 wrap:                       "auto"
 columns:                    78
+strip-comments              true
 toc:                        true
 table_of_contents:          true
 toc_depth:                  3


### PR DESCRIPTION
See https://github.com/jgm/pandoc/commit/b1ee747a249e0c1b1840222ef77607218157f099 — if nothing is passed default is `false`, if this option is specified it becomes `true`.