### PR TITLE
fixes related to matching bullet list children

### DIFF
--- a/lib/paru/filter/list.rb
+++ b/lib/paru/filter/list.rb
@@ -31,7 +31,10 @@ module Paru
             def initialize(contents, node_class = Block)
                 super []
                 contents.each do |item|
-                    @children.push node_class.new item
+                    child = node_class.new(item)
+                    child.parent = self
+
+                    @children.push child
                 end
             end
 

--- a/lib/paru/selector.rb
+++ b/lib/paru/selector.rb
@@ -187,8 +187,10 @@ module Paru
 
         def is_descendant?(node)
             distance = 0
+            parent = nil
             begin
                 distance += 1 if @distance > 0
+                node = parent unless parent.nil?
                 parent = node.parent
                 ancestry = parent.type == @type and @classes.all? {|c| parent.has_class? c}
             end while not ancestry and not parent.is_root? and distance <= @distance

--- a/test/pandoc_input/bullet_list_with_followers.md
+++ b/test/pandoc_input/bullet_list_with_followers.md
@@ -1,0 +1,6 @@
+- first item
+- second *important* item
+- third item
+
+1. fourth
+1. fifth

--- a/test/pandoc_input/deep_descendent.md
+++ b/test/pandoc_input/deep_descendent.md
@@ -1,0 +1,3 @@
+* dont upcase parent
+  * dont upcase bullet
+    1. do upcase child number

--- a/test/pandoc_output/bullet_list_with_followers.md
+++ b/test/pandoc_output/bullet_list_with_followers.md
@@ -1,0 +1,6 @@
+-   FIRST ITEM
+-   SECOND *IMPORTANT* ITEM
+-   THIRD ITEM
+
+1.  fourth
+2.  fifth

--- a/test/pandoc_output/deep_descendent.md
+++ b/test/pandoc_output/deep_descendent.md
@@ -1,5 +1,3 @@
 -   dont upcase parent
     -   dont upcase bullet
         1.  DO UPCASE CHILD NUMBER
-
-

--- a/test/pandoc_output/deep_descendent.md
+++ b/test/pandoc_output/deep_descendent.md
@@ -1,0 +1,5 @@
+-   dont upcase parent
+    -   dont upcase bullet
+        1.  DO UPCASE CHILD NUMBER
+
+

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -218,6 +218,17 @@ class FilterTest < MiniTest::Test
         end
     end
 
+    def test_deep_descendent()
+        filter_file_and_equal_file(
+            "test/pandoc_input/deep_descendent.md",
+            "test/pandoc_output/deep_descendent.md"
+        ) do
+            with "BulletList > OrderedList > Plain" do |item|
+                item.inner_markdown = item.inner_markdown.upcase
+            end
+        end
+    end
+
     def test_insert_code_block()
         filter_file_and_equal_file(
             "test/pandoc_input/insert_code_blocks.md",

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -149,6 +149,17 @@ class FilterTest < MiniTest::Test
         end
     end
 
+    def test_capitalize_list_elements()
+        filter_file_and_equal_file(
+            "test/pandoc_input/bullet_list_with_followers.md",
+            "test/pandoc_output/bullet_list_with_followers.md"
+        ) do
+            with "BulletList > Str" do |str|
+                str.string = str.string.upcase
+            end
+        end
+    end
+
     def test_number_figures()
         figure_counter = 0
 


### PR DESCRIPTION
In trying to build a filter which manipulated "task list" items, I ran into a few bugs:

```ruby
with("BulletList > Str") do |item|
   # ...
end
```

* descendent selector loops infinitely

   Due to what looks like a simple bug in `Relation#is_descendent?`, that method will loop forever if a match isn't found in a node's immediate parent. This hadn't yet been caught by tests, because the test for descendent selectors only looks at it's immediate parent.

* list items can't participant in descendent selector

   The `List` node adds its children itself, and diverges from `Node#initialize` in that it doesn't set the children's parent reference.

---

Let me know if there's anything I can do to help land these, this library is _really_ cool.