### PR TITLE
fix definition list item contents not participating in tree search

### DIFF
--- a/lib/paru/filter/definition_list.rb
+++ b/lib/paru/filter/definition_list.rb
@@ -30,7 +30,10 @@ module Paru
             def initialize(contents)
                 super []
                 contents.each do |item|
-                    @children.push DefinitionListItem.new item
+                    child = DefinitionListItem.new item
+                    child.parent = self
+
+                    @children.push child
                 end
             end
 

--- a/lib/paru/filter/definition_list_item.rb
+++ b/lib/paru/filter/definition_list_item.rb
@@ -37,8 +37,15 @@ module Paru
             #
             # @param item [Array] the [term, definition]
             def initialize(item)
+                super []
+
                 @term = Block.new item[0]
+                @term.parent = self
+                @children << @term
+
                 @definition = List.new item[1]
+                @definition.parent = self
+                @children << @definition
             end
 
             # Create an AST representation of this DefinitionListItem

--- a/test/pandoc_input/definition_list_paras.md
+++ b/test/pandoc_input/definition_list_paras.md
@@ -1,0 +1,15 @@
+An initial paragraph outside the list
+
+Term 1
+
+:   Definition 1
+
+Term 2 with *inline markup*
+
+:   Definition 2
+
+        {some code, part of def 2}
+
+    Another paragraph
+
+A paragraph outside the list

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -504,6 +504,30 @@ class FilterTest < MiniTest::Test
         assert_match(output, File.read("test/pandoc_input/bullet_list.md"))
     end
 
+    def test_definition_list_item_children()
+        paras = []
+        filter_file("test/pandoc_input/definition_list_paras.md") do
+            with "Para" do |p|
+                paras << p
+            end
+        end
+
+        # two outside and three inside the list
+        assert_equal(5, paras.length)
+    end
+
+    def test_definition_list_item_descendent_selector()
+        paras = []
+        filter_file("test/pandoc_input/definition_list_paras.md") do
+            with "DefinitionList > Para" do |p|
+                paras << p
+            end
+        end
+
+        # only the three inside the list
+        assert_equal(3, paras.length)
+    end
+
     def test_definition_list_convenience()
         list = []
         filter_file("test/pandoc_input/definition_list.md") do


### PR DESCRIPTION
After #69 , I went looking for other instances of a similar pattern (block elements not adding to `@children`, or missing `parent` references):

* `DefinitionListItem` didn't add it's term and definition as children,
meaning they weren't enumerated during filtering

* `DefinitionList` didn't add list items with parent pointers, meaning
they couldn't be searched for descendent selectors

---

There's also some weirdness in `@parent` references for `Table`-related nodes, but that was complicated enough, and with unclear enough semantics, to not get included in this pass.

Hope you're well!